### PR TITLE
Remove data type contexts which trigger these errors with ghc-7.8.3

### DIFF
--- a/src/Data/Ranged/RangedSet.hs
+++ b/src/Data/Ranged/RangedSet.hs
@@ -69,7 +69,7 @@ infixl 5 -<=-, -<-, -?-
 
 -- | An RSet (for Ranged Set) is a list of ranges.  The ranges must be sorted
 -- and not overlap.
-newtype DiscreteOrdered v => RSet v = RSet {rSetRanges :: [Range v]}
+newtype RSet v = RSet {rSetRanges :: [Range v]}
    deriving (Eq, Show, Ord)
 
 instance DiscreteOrdered a => Monoid (RSet a) where

--- a/src/Data/Ranged/Ranges.hs
+++ b/src/Data/Ranged/Ranges.hs
@@ -51,7 +51,7 @@ import Data.Maybe
 import Test.QuickCheck
 
 -- | A Range has upper and lower boundaries.
-data Ord v => Range v = Range {rangeLower, rangeUpper :: Boundary v}
+data Range v = Range {rangeLower, rangeUpper :: Boundary v}
 
 instance (DiscreteOrdered a) => Eq (Range a) where
    r1 == r2   = (rangeIsEmpty r1 && rangeIsEmpty r2) ||


### PR DESCRIPTION
when building alex-3.1.3.

src/Data/Ranged/RangedSet.hs:72:9:
    Illegal datatype context (use DatatypeContexts): DiscreteOrdered v =>

src/Data/Ranged/Ranges.hs:54:6:
    Illegal datatype context (use DatatypeContexts): Ord v =>