### PR TITLE
Fix Issue #51

### DIFF
--- a/tests/tokens_monadUserState_bytestring.x
+++ b/tests/tokens_monadUserState_bytestring.x
@@ -24,7 +24,7 @@ tokens :-
 -- Each right-hand side has type :: AlexPosn -> String -> Token
 
 -- Some action helpers:
-tok f (p,_,input) len = return (f p (B.take (fromIntegral len) input))
+tok f (p,_,input,_) len = return (f p (B.take (fromIntegral len) input))
 
 -- The token type:
 data Token =

--- a/tests/tokens_monad_bytestring.x
+++ b/tests/tokens_monad_bytestring.x
@@ -24,7 +24,7 @@ tokens :-
 -- Each right-hand side has type :: AlexPosn -> String -> Token
 
 -- Some action helpers:
-tok f (p,_,input) len = return (f p (B.take (fromIntegral len) input))
+tok f (p,_,input,_) len = return (f p (B.take (fromIntegral len) input))
 
 -- The token type:
 data Token =


### PR DESCRIPTION
This fixes Issue #51.We make all ByteString wrappers keep track of the number of bytes yielded, so ByteString.length does not need to be called and the whole string does not need to be traversed.