### PR TITLE
Added {-# OPTIONS_GHC -w #-} for tools like ghc-mod to stop reporting errors

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -203,8 +203,11 @@ injectCode (Just (AlexPn _ ln _,code)) filename hdl = do
   hPutStrLn hdl code
 
 optsToInject :: Target -> [CLIFlags] -> String
-optsToInject GhcTarget _ = "{-# LANGUAGE CPP,MagicHash #-}\n"
-optsToInject _         _ = "{-# LANGUAGE CPP #-}\n"
+optsToInject GhcTarget _ = optNoWarnings ++ "{-# LANGUAGE CPP,MagicHash #-}\n"
+optsToInject _         _ = optNoWarnings ++ "{-# LANGUAGE CPP #-}\n"
+
+optNoWarnings :: String
+optNoWarnings = "{-# OPTIONS_GHC -w #-}\n"
 
 importsToInject :: Target -> [CLIFlags] -> String
 importsToInject _ cli = always_imports ++ debug_imports ++ glaexts_import


### PR DESCRIPTION
Like #50 but without the whitespace changes.