### PR TITLE
Adds flag '--tab-size=NUMBER / -s NUMBER'

### DIFF
--- a/templates/wrappers.hs
+++ b/templates/wrappers.hs
@@ -149,7 +149,7 @@ alexStartPos :: AlexPosn
 alexStartPos = AlexPn 0 1 1
 
 alexMove :: AlexPosn -> Char -> AlexPosn
-alexMove (AlexPn a l c) '\t' = AlexPn (a+1)  l     (((c+7) `div` 8)*8+1)
+alexMove (AlexPn a l c) '\t' = AlexPn (a+1)  l     (((c+alex_tab_size-1) `div` alex_tab_size)*alex_tab_size+1)
 alexMove (AlexPn a l c) '\n' = AlexPn (a+1) (l+1)   1
 alexMove (AlexPn a l c) _    = AlexPn (a+1)  l     (c+1)
 #endif


### PR DESCRIPTION
for setting the desired size of the tab charachter ('\t'), it defaults
to 8 for backwards compatibility.