### PR TITLE
Fix some build-time warnings

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -21,7 +21,7 @@ main = defaultMainWithHooks simpleUserHooks{ postBuild = myPostBuild,
                                              copyHook  = myCopy,
                                              instHook  = myInstall }
 
--- hack to turn cpp-style '# 27 "GenericTemplate.hs"' into 
+-- hack to turn cpp-style '# 27 "GenericTemplate.hs"' into
 -- '{-# LINE 27 "GenericTemplate.hs" #-}'.
 mungeLinePragma line = case symbols line of
  syms | Just prag <- getLinePrag syms  -> prag
@@ -53,7 +53,7 @@ myPostBuild _ flags _ lbi = do
         removeFile tmp
 
   sequence_ ([ cpp_template "GenericTemplate.hs" dst opts | (dst,opts) <- templates ] ++
-  	     [ cpp_template "wrappers.hs"        dst opts | (dst,opts) <- wrappers ])
+             [ cpp_template "wrappers.hs"        dst opts | (dst,opts) <- wrappers ])
 
 myPostClean _ _ _ _ = let try' = try :: IO a -> IO (Either IOException a)
                       in mapM_ (try' . removeFile) all_template_files
@@ -62,13 +62,13 @@ myInstall pkg_descr lbi hooks flags =
   instHook simpleUserHooks pkg_descr' lbi hooks flags
   where pkg_descr' = pkg_descr {
           dataFiles = dataFiles pkg_descr ++ all_template_files
-	}
+        }
 
 myCopy pkg_descr lbi hooks copy_flags =
   copyHook simpleUserHooks pkg_descr' lbi hooks copy_flags
   where pkg_descr' = pkg_descr {
           dataFiles = dataFiles pkg_descr ++ all_template_files
-	}
+        }
 
 all_template_files :: [FilePath]
 all_template_files = map fst (templates ++ wrappers)

--- a/alex.cabal
+++ b/alex.cabal
@@ -41,43 +41,43 @@ cabal-version: >= 1.8
 build-type: Custom
 
 extra-source-files:
-	ANNOUNCE
-	README
-	TODO
-	alex.spec
-	doc/Makefile
-	doc/aclocal.m4
-	doc/alex.1.in
-	doc/alex.xml
-	doc/config.mk.in
-	doc/configure.ac
-	doc/docbook-xml.mk
-	doc/fptools.css
-	examples/Makefile
-	examples/Tokens.x
-	examples/Tokens_gscan.x
-	examples/Tokens_posn.x
-	examples/examples.x
-	examples/haskell.x
-	examples/lit.x
-	examples/pp.x
-	examples/state.x
-	examples/tiny.y
-	examples/tkns.hs
-	examples/words.x
-	examples/words_monad.x
-	examples/words_posn.x
-	src/Parser.y
-	src/Scan.hs
-	src/ghc_hooks.c
-	templates/GenericTemplate.hs
+        ANNOUNCE
+        README
+        TODO
+        alex.spec
+        doc/Makefile
+        doc/aclocal.m4
+        doc/alex.1.in
+        doc/alex.xml
+        doc/config.mk.in
+        doc/configure.ac
+        doc/docbook-xml.mk
+        doc/fptools.css
+        examples/Makefile
+        examples/Tokens.x
+        examples/Tokens_gscan.x
+        examples/Tokens_posn.x
+        examples/examples.x
+        examples/haskell.x
+        examples/lit.x
+        examples/pp.x
+        examples/state.x
+        examples/tiny.y
+        examples/tkns.hs
+        examples/words.x
+        examples/words_monad.x
+        examples/words_posn.x
+        src/Parser.y
+        src/Scan.hs
+        src/ghc_hooks.c
+        templates/GenericTemplate.hs
         templates/wrappers.hs
-	tests/Makefile
+        tests/Makefile
         tests/simple.x
         tests/null.x
         tests/tokens.x
-	tests/tokens_gscan.x
-	tests/tokens_posn.x
+        tests/tokens_gscan.x
+        tests/tokens_posn.x
         tests/tokens_bytestring.x
         tests/tokens_posn_bytestring.x
         tests/tokens_strict_bytestring.x

--- a/src/CharSet.hs
+++ b/src/CharSet.hs
@@ -1,5 +1,5 @@
 -- -----------------------------------------------------------------------------
--- 
+--
 -- CharSet.hs, part of Alex
 --
 -- (c) Chris Dornan 1995-2000, Simon Marlow 2003
@@ -108,9 +108,9 @@ toUtfRange :: Span [Byte] -> [Span [Byte]]
 toUtfRange (Span x y) = fix x y
 
 fix :: [Byte] -> [Byte] -> [Span [Byte]]
-fix x y 
+fix x y
     | length x == length y = [Span x y]
-    | length x == 1 = Span x [0x7F] : fix [0xC2,0x80] y    
+    | length x == 1 = Span x [0x7F] : fix [0xC2,0x80] y
     | length x == 2 = Span x [0xDF,0xBF] : fix [0xE0,0x80,0x80] y
     | length x == 3 = Span x [0xEF,0xBF,0xBF] : fix [0xF0,0x80,0x80,0x80] y
     | otherwise = error "fix: incorrect input given"
@@ -151,14 +151,9 @@ byteSetRange c1 c2 = makeRangedSet [Range (BoundaryBelow c1) (BoundaryAbove c2)]
 byteSetSingleton :: Byte -> ByteSet
 byteSetSingleton = rSingleton
 
-instance DiscreteOrdered Word8 where
-    adjacent x y = x + 1 == y
-    adjacentBelow 0 = Nothing
-    adjacentBelow x = Just (x-1)
-
 -- TODO: More efficient generated code!
 charSetQuote :: CharSet -> String
-charSetQuote s = "(\\c -> " ++ foldr (\x y -> x ++ " || " ++ y) "False" (map quoteRange (rSetRanges s)) ++ ")" 
+charSetQuote s = "(\\c -> " ++ foldr (\x y -> x ++ " || " ++ y) "False" (map quoteRange (rSetRanges s)) ++ ")"
     where quoteRange (Range l h) = quoteL l ++ " && " ++ quoteH h
           quoteL (BoundaryAbove a) = "c > " ++ show a
           quoteL (BoundaryBelow a) = "c >= " ++ show a

--- a/src/Data/Ranged/Boundaries.hs
+++ b/src/Data/Ranged/Boundaries.hs
@@ -20,6 +20,7 @@ module Data.Ranged.Boundaries (
 ) where
 
 import Data.Ratio
+import Data.Word
 import Test.QuickCheck
 
 infix 4 />/
@@ -118,6 +119,11 @@ instance (Ord a, Ord b, Ord c, DiscreteOrdered d) =>
       adjacentBelow (x1, x2, x3, x4) = do -- Maybe monad
          x4' <- adjacentBelow x4
          return (x1, x2, x3, x4')
+
+instance DiscreteOrdered Word8 where
+    adjacent x y = x + 1 == y
+    adjacentBelow 0 = Nothing
+    adjacentBelow x = Just (x-1)
 
 
 -- | Check adjacency for sparse enumerated types (i.e. where there


### PR DESCRIPTION
Remove tabs from Setup.lhs to quiet down ghc 7.10. I also took liberty to remove tabs from cabal file although that didn't make any difference w.r.t. warnings.

Also, `DiscreteOrdered Word8` instance wan an orphan for some reason.