### PR TITLE
Fix all warnings in generated code

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,5 @@
 ALEX=../dist/build/alex/alex
-HC=ghc -Wall -fno-warn-unused-binds -fno-warn-missing-signatures -fno-warn-unused-matches -fno-warn-name-shadowing -fno-warn-unused-imports
+HC=ghc -Wall -fno-warn-unused-binds -fno-warn-missing-signatures -fno-warn-unused-matches -fno-warn-name-shadowing -fno-warn-unused-imports -fno-warn-tabs
 
 HAPPY=happy
 HAPPY_OPTS=-agc

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -230,11 +230,9 @@ always_imports = "#if __GLASGOW_HASKELL__ >= 603\n" ++
                  "#endif\n" ++
                  "#if __GLASGOW_HASKELL__ >= 503\n" ++
                  "import Data.Array\n" ++
-                 "import Data.Char (ord)\n" ++
                  "import Data.Array.Base (unsafeAt)\n" ++
                  "#else\n" ++
                  "import Array\n" ++
-                 "import Char (ord)\n" ++
                  "#endif\n"
 
 import_glaexts :: String

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -207,7 +207,7 @@ optsToInject GhcTarget _ = optNoWarnings ++ "{-# LANGUAGE CPP,MagicHash #-}\n"
 optsToInject _         _ = optNoWarnings ++ "{-# LANGUAGE CPP #-}\n"
 
 optNoWarnings :: String
-optNoWarnings = "{-# OPTIONS_GHC -w #-}\n"
+optNoWarnings = "{-# OPTIONS_GHC -fno-warn-unused-binds -fno-warn-missing-signatures #-}\n"
 
 importsToInject :: Target -> [CLIFlags] -> String
 importsToInject _ cli = always_imports ++ debug_imports ++ glaexts_import

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -239,6 +239,3 @@ alexRightContext IBOX(sc) user _ _ input =
         -- match when checking the right context, just
         -- the first match will do.
 #endif
-
--- used by wrappers
-iUnbox IBOX(i) = i

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -202,9 +202,9 @@ data AlexLastAcc a
   | AlexLastSkip  !AlexInput !Int
 
 instance Functor AlexLastAcc where
-    fmap f AlexNone = AlexNone
+    fmap _ AlexNone = AlexNone
     fmap f (AlexLastAcc x y z) = AlexLastAcc (f x) y z
-    fmap f (AlexLastSkip x y) = AlexLastSkip x y
+    fmap _ (AlexLastSkip x y) = AlexLastSkip x y
 
 data AlexAcc a user
   = AlexAccNone

--- a/templates/GenericTemplate.hs
+++ b/templates/GenericTemplate.hs
@@ -79,8 +79,8 @@ ALEX_IF_BIGENDIAN
   narrow32Int# i
   where
    i    = word2Int# ((b3 `uncheckedShiftL#` 24#) `or#`
-		     (b2 `uncheckedShiftL#` 16#) `or#`
-		     (b1 `uncheckedShiftL#` 8#) `or#` b0)
+                     (b2 `uncheckedShiftL#` 16#) `or#`
+                     (b1 `uncheckedShiftL#` 8#) `or#` b0)
    b3   = int2Word# (ord# (indexCharOffAddr# arr (off' +# 3#)))
    b2   = int2Word# (ord# (indexCharOffAddr# arr (off' +# 2#)))
    b1   = int2Word# (ord# (indexCharOffAddr# arr (off' +# 1#)))
@@ -120,30 +120,30 @@ alexScan input IBOX(sc)
 
 alexScanUser user input IBOX(sc)
   = case alex_scan_tkn user input ILIT(0) input sc AlexNone of
-	(AlexNone, input') ->
-		case alexGetByte input of
-			Nothing -> 
+        (AlexNone, input') ->
+                case alexGetByte input of
+                        Nothing -> 
 #ifdef ALEX_DEBUG
-				   trace ("End of input.") $
+                                   trace ("End of input.") $
 #endif
-				   AlexEOF
-			Just _ ->
+                                   AlexEOF
+                        Just _ ->
 #ifdef ALEX_DEBUG
-				   trace ("Error.") $
+                                   trace ("Error.") $
 #endif
-				   AlexError input'
+                                   AlexError input'
 
-	(AlexLastSkip input'' len, _) ->
+        (AlexLastSkip input'' len, _) ->
 #ifdef ALEX_DEBUG
-		trace ("Skipping.") $ 
+                trace ("Skipping.") $ 
 #endif
-		AlexSkip input'' len
+                AlexSkip input'' len
 
-	(AlexLastAcc k input''' len, _) ->
+        (AlexLastAcc k input''' len, _) ->
 #ifdef ALEX_DEBUG
-		trace ("Accept.") $ 
+                trace ("Accept.") $ 
 #endif
-		AlexToken input''' len k
+                AlexToken input''' len k
 
 
 -- Push the input through the DFA, remembering the most recent accepting
@@ -152,7 +152,7 @@ alexScanUser user input IBOX(sc)
 alex_scan_tkn user orig_input len input s last_acc =
   input `seq` -- strict in the input
   let 
-	new_acc = (check_accs (alex_accept `quickIndex` IBOX(s)))
+        new_acc = (check_accs (alex_accept `quickIndex` IBOX(s)))
   in
   new_acc `seq`
   case alexGetByte input of
@@ -166,34 +166,34 @@ alex_scan_tkn user orig_input len input s last_acc =
                 base   = alexIndexInt32OffAddr alex_base s
                 offset = PLUS(base,ord_c)
                 check  = alexIndexInt16OffAddr alex_check offset
-		
+                
                 new_s = if GTE(offset,ILIT(0)) && EQ(check,ord_c)
-			  then alexIndexInt16OffAddr alex_table offset
-			  else alexIndexInt16OffAddr alex_deflt s
-	in
+                          then alexIndexInt16OffAddr alex_table offset
+                          else alexIndexInt16OffAddr alex_deflt s
+        in
         case new_s of
-	    ILIT(-1) -> (new_acc, input)
-		-- on an error, we want to keep the input *before* the
-		-- character that failed, not after.
-    	    _ -> alex_scan_tkn user orig_input (if c < 0x80 || c >= 0xC0 then PLUS(len,ILIT(1)) else len)
+            ILIT(-1) -> (new_acc, input)
+                -- on an error, we want to keep the input *before* the
+                -- character that failed, not after.
+            _ -> alex_scan_tkn user orig_input (if c < 0x80 || c >= 0xC0 then PLUS(len,ILIT(1)) else len)
                                                 -- note that the length is increased ONLY if this is the 1st byte in a char encoding)
-			new_input new_s new_acc
+                        new_input new_s new_acc
       }
   where
-	check_accs (AlexAccNone) = last_acc
-	check_accs (AlexAcc a  ) = AlexLastAcc a input IBOX(len)
-	check_accs (AlexAccSkip) = AlexLastSkip  input IBOX(len)
+        check_accs (AlexAccNone) = last_acc
+        check_accs (AlexAcc a  ) = AlexLastAcc a input IBOX(len)
+        check_accs (AlexAccSkip) = AlexLastSkip  input IBOX(len)
 #ifndef ALEX_NOPRED
-	check_accs (AlexAccPred a predx rest)
-	   | predx user orig_input IBOX(len) input
-	   = AlexLastAcc a input IBOX(len)
-	   | otherwise
-	   = check_accs rest
-	check_accs (AlexAccSkipPred predx rest)
-	   | predx user orig_input IBOX(len) input
-	   = AlexLastSkip input IBOX(len)
-	   | otherwise
-	   = check_accs rest
+        check_accs (AlexAccPred a predx rest)
+           | predx user orig_input IBOX(len) input
+           = AlexLastAcc a input IBOX(len)
+           | otherwise
+           = check_accs rest
+        check_accs (AlexAccSkipPred predx rest)
+           | predx user orig_input IBOX(len) input
+           = AlexLastSkip input IBOX(len)
+           | otherwise
+           = check_accs rest
 #endif
 
 data AlexLastAcc a
@@ -233,11 +233,11 @@ alexPrevCharIsOneOf arr _ input _ _ = arr ! alexInputPrevChar input
 --alexRightContext :: Int -> AlexAccPred _
 alexRightContext IBOX(sc) user _ _ input = 
      case alex_scan_tkn user input ILIT(0) input sc AlexNone of
-	  (AlexNone, _) -> False
-	  _ -> True
-	-- TODO: there's no need to find the longest
-	-- match when checking the right context, just
-	-- the first match will do.
+          (AlexNone, _) -> False
+          _ -> True
+        -- TODO: there's no need to find the longest
+        -- match when checking the right context, just
+        -- the first match will do.
 #endif
 
 -- used by wrappers

--- a/templates/wrappers.hs
+++ b/templates/wrappers.hs
@@ -23,6 +23,7 @@ import qualified Data.ByteString.Unsafe   as ByteString
 
 #else
 
+import Data.Char (ord)
 import qualified Data.Bits
 
 -- | Encode a Haskell String to a list of Word8 values, in UTF8 format.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 ALEX=../dist/build/alex/alex
 HC=ghc
-HC_OPTS=-Wall -fno-warn-unused-binds -fno-warn-missing-signatures -fno-warn-unused-matches -fno-warn-name-shadowing -fno-warn-unused-imports
+HC_OPTS=-Wall -fno-warn-unused-binds -fno-warn-missing-signatures -fno-warn-unused-matches -fno-warn-name-shadowing -fno-warn-unused-imports -fno-warn-tabs -Werror
 
 .PRECIOUS: %.n.hs %.g.hs %.o %.exe %.bin
 


### PR DESCRIPTION
Well... almost. `-fno-warn-unused-binds` and `-fno-warn-missing-signatures` are still
needed. But we don't need `-w`. As I mentioned in [1], I think `-w` is a bad default, as it hides bugs in user code.

Requires a major version upgrade for the removal of `iUnbox`, and for not importing `Data.Char (ord)` in the generated code.

[1] https://github.com/simonmar/alex/commit/1eefcde22ba1bb9b51d523814415714e20f0761e#commitcomment-12002704