### PR TITLE
Fix non-exhaustive pattern in templates/wrapper.hs

### DIFF
--- a/templates/wrappers.hs
+++ b/templates/wrappers.hs
@@ -70,8 +70,9 @@ alexGetByte :: AlexInput -> Maybe (Byte,AlexInput)
 alexGetByte (p,c,(b:bs),s) = Just (b,(p,c,bs,s))
 alexGetByte (p,c,[],[]) = Nothing
 alexGetByte (p,_,[],(c:s))  = let p' = alexMove p c 
-                                  bs = utf8Encode c
-                              in p' `seq` Just (head bs, (p', c, tail bs, s))
+                              in case utf8Encode c of
+                                [] -> error "utf8Encode returned empty list"
+                                (b:bs) -> p' `seq` Just (b, (p', c, bs, s))
 #endif
 
 #if defined(ALEX_POSN_BYTESTRING) || defined(ALEX_MONAD_BYTESTRING)

--- a/templates/wrappers.hs
+++ b/templates/wrappers.hs
@@ -70,8 +70,8 @@ alexGetByte :: AlexInput -> Maybe (Byte,AlexInput)
 alexGetByte (p,c,(b:bs),s) = Just (b,(p,c,bs,s))
 alexGetByte (p,c,[],[]) = Nothing
 alexGetByte (p,_,[],(c:s))  = let p' = alexMove p c 
-                                  (b:bs) = utf8Encode c
-                              in p' `seq`  Just (b, (p', c, bs, s))
+                                  bs = utf8Encode c
+                              in p' `seq` Just (head bs, (p', c, tail bs, s))
 #endif
 
 #if defined(ALEX_POSN_BYTESTRING) || defined(ALEX_MONAD_BYTESTRING)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 ALEX=../dist/build/alex/alex
 HC=ghc
-HC_OPTS=-Wall -fno-warn-unused-binds -fno-warn-missing-signatures -fno-warn-unused-matches -fno-warn-name-shadowing -fno-warn-unused-imports -fno-warn-tabs -Werror
+HC_OPTS=-Wall -fwarn-incomplete-patterns -fwarn-incomplete-uni-patterns -fno-warn-unused-binds -fno-warn-missing-signatures -fno-warn-unused-matches -fno-warn-name-shadowing -fno-warn-unused-imports -fno-warn-tabs -Werror
 
 .PRECIOUS: %.n.hs %.g.hs %.o %.exe %.bin
 


### PR DESCRIPTION
Non-exhaustive pattern in the wrapper is undesirable since third parties
using the wrapper will see a warning that's not related to their code.
