### PR TITLE
Implement %encoding directive

### DIFF
--- a/doc/alex.xml
+++ b/doc/alex.xml
@@ -544,7 +544,7 @@ $graphic    = $printable # $white
 
       <para>The overall layout of an Alex file is:</para>
 
-<programlisting>alex := [ @code ] [ wrapper ] { macrodef } @id ':-' { rule } [ @code ]</programlisting>
+<programlisting>alex := [ @code ] [ wrapper ] [ encoding ] { macrodef } @id ':-' { rule } [ @code ]</programlisting>
 
       <para>The file begins and ends with optional code fragments.
       These code fragments are copied verbatim into the generated
@@ -562,8 +562,12 @@ $graphic    = $printable # $white
 
 <programlisting>wrapper := '%wrapper' @string</programlisting>
 
-      <para>wrappers are described in <xref
-      linkend="wrappers"/>.</para>
+      <para>wrappers are described in <xref linkend="wrappers"/>. This
+      can be followed by an optional encoding declaration:</para>
+
+<programlisting>encoding := '%encoding' @string</programlisting>
+
+      <para>encodings are described in <xref linkend="encoding"/>.</para>
 
       <section id="macrodefs">
 	<title>Macro definitions</title>
@@ -1088,10 +1092,33 @@ $del      = \127                  -- ASCII DEL</programlisting>
 
       <para>
         None of this applies if you used the <option>--latin1</option>
-        option to Alex.  In that case, the input is just a sequence of
-        8-bit bytes, interpreted as characters in the Latin-1
+        option to Alex or specify a Latin-1 encoding via a
+        <literal>%encoding</literal> declaration.  In that case, the input is
+        just a sequence of 8-bit bytes, interpreted as characters in the Latin-1
         character set.
       </para>
+
+      <para>
+        The following (case-insenstive) encoding strings are currently
+        supported:
+      </para>
+
+      <variablelist>
+        <varlistentry>
+          <term><literal>%encoding "latin-1"</literal></term>
+          <term><literal>%encoding "iso-8859-1"</literal></term>
+          <listitem><para>Declare Latin-1 encoding as described above.</para></listitem>
+        </varlistentry>
+        <varlistentry>
+          <term><literal>%encoding "utf-8"</literal></term>
+          <term><literal>%encoding "utf8"</literal></term>
+          <listitem><para>Declare UTF-8 encoding. This is
+          the default encoding but it may be useful to explicitly declare
+          this to make protect against Alex being called with the
+          <option>--latin1</option> flag.</para></listitem>
+        </varlistentry>
+      </variablelist>
+
     </section>
 
     <section id="basic-api">
@@ -1523,7 +1550,8 @@ type StopAction state result
           lexers internally process a UTF-8 encoded string of bytes.
           This means that the <literal>ByteString</literal> supplied
           as input when using one of the ByteString wrappers should be
-          UTF-8 encoded (or use the <option>--latin1</option> option).
+          UTF-8 encoded (or use either the <option>--latin1</option>
+          option or the <literal>%encoding</literal> declaration).
         </para>
 
         <para>Do note that <literal>token</literal> provides a
@@ -1754,6 +1782,11 @@ runAlex          :: ByteString.ByteString -> Alex a -> Either String a
           so <option>--latin1</option> does not make sense in
           conjunction with these wrappers (not that you would want to
           do that, anyway).
+
+          Alternatively, a <literal>%encoding "latin1"</literal> declaration can be
+          used inside the Alex source file to request a Latin-1 mapping. See also
+          <xref linkend="encoding" /> for more information about the
+          <literal>%encoding</literal> declaration.
           </para>
         </listitem>
       </varlistentry>

--- a/src/AbsSyn.hs
+++ b/src/AbsSyn.hs
@@ -21,7 +21,7 @@ module AbsSyn (
   UsesPreds(..), usesPreds
   ) where
 
-import CharSet ( CharSet )
+import CharSet ( CharSet, Encoding )
 import Map ( Map )
 import qualified Map hiding ( Map )
 import Data.IntMap (IntMap)
@@ -40,6 +40,8 @@ type Code = String
 
 data Directive
    = WrapperDirective String            -- use this wrapper
+   | EncodingDirective Encoding         -- use this encoding
+   deriving Show
 
 -- TODO: update this comment
 --

--- a/src/CharSet.hs
+++ b/src/CharSet.hs
@@ -51,6 +51,7 @@ type ByteSet = RSet Byte
 type Utf8Range = Span [Byte]
 
 data Encoding = Latin1 | UTF8
+              deriving (Eq, Show)
 
 emptyCharSet :: CharSet
 emptyCharSet = rSetEmpty

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -59,6 +59,7 @@ import Data.Char
 	SMAC_DEF	{ T _ (SMacDefT $$) }
 	RMAC_DEF	{ T _ (RMacDefT $$) }
 	WRAPPER		{ T _ WrapperT }
+	ENCODING	{ T _ EncodingT }
 %%
 
 alex	:: { (Maybe (AlexPosn,Code), [Directive], Scanner, Maybe (AlexPosn,Code)) }
@@ -75,7 +76,11 @@ directives :: { [Directive] }
 
 directive  :: { Directive }
 	: WRAPPER STRING		{ WrapperDirective $2 }
+	| ENCODING encoding		{ EncodingDirective $2 }
 
+encoding :: { Encoding }
+        : STRING         		{% lookupEncoding $1 }
+        
 macdefs :: { () }
 	: macdef macdefs		{ () }
 	| {- empty -}			{ () }
@@ -217,4 +222,13 @@ repeat_rng n (Just (Just m)) re = intl :%% rst
 	rst = foldr (\re re'->Ques(re :%% re')) Eps (replicate (m-n) re)
 
 replaceCodes codes rectx = rectx{ reCtxStartCodes = codes }
+
+lookupEncoding :: String -> P Encoding
+lookupEncoding s = case map toLower s of
+  "iso-8859-1" -> return Latin1
+  "latin1"     -> return Latin1
+  "utf-8"      -> return UTF8
+  "utf8"       -> return UTF8
+  _            -> failP ("encoding " ++ show s ++ " not supported")
+
 }

--- a/src/Scan.x
+++ b/src/Scan.x
@@ -49,6 +49,7 @@ alex :-
 <0> \{ / (\n | [^$digit])       { code }
 <0> $special			{ special }  -- note: matches {
 <0> \% "wrapper"		{ wrapper }
+<0> \% "encoding"		{ encoding }
 
 <0> \\ $digit+			{ decch }
 <0> \\ x $hexdig+		{ hexch }
@@ -96,6 +97,7 @@ data Tkn
  | RMacDefT String  
  | NumT Int	
  | WrapperT
+ | EncodingT
  | EOFT
  deriving Show
 
@@ -117,6 +119,7 @@ smacdef   (p,_,str) ln = return $ T p (SMacDefT (macdef ln str))
 rmacdef   (p,_,str) ln = return $ T p (RMacDefT (macdef ln str))
 startcode (p,_,str) ln = return $ T p (IdT (take ln str))
 wrapper   (p,_,str) ln = return $ T p WrapperT
+encoding  (p,_,str) ln = return $ T p EncodingT
 
 isIdChar c = isAlphaNum c || c `elem` "_'"
 

--- a/tests/tokens_bytestring.x
+++ b/tests/tokens_bytestring.x
@@ -6,6 +6,7 @@ import Data.ByteString.Lazy.Char8 (unpack)
 }
 
 %wrapper "basic-bytestring"
+%encoding "latin1"
 
 $digit = 0-9			-- digits
 $alpha = [a-zA-Z]		-- alphabetic characters

--- a/tests/tokens_bytestring_unicode.x
+++ b/tests/tokens_bytestring_unicode.x
@@ -6,6 +6,7 @@ import Data.ByteString.Lazy.Char8 (unpack)
 }
 
 %wrapper "basic-bytestring"
+%encoding "utf-8"
 
 $digit = 0-9      -- digits
 $alpha = [a-zA-Zαβ]    -- alphabetic characters

--- a/tests/tokens_monadUserState_bytestring.x
+++ b/tests/tokens_monadUserState_bytestring.x
@@ -6,6 +6,7 @@ import qualified Data.ByteString.Lazy.Char8 as B
 }
 
 %wrapper "monadUserState-bytestring"
+%encoding "iso-8859-1"
 
 $digit = 0-9			-- digits
 $alpha = [a-zA-Z]		-- alphabetic characters

--- a/tests/tokens_monad_bytestring.x
+++ b/tests/tokens_monad_bytestring.x
@@ -6,6 +6,7 @@ import qualified Data.ByteString.Lazy.Char8 as B
 }
 
 %wrapper "monad-bytestring"
+%encoding "Latin1"
 
 $digit = 0-9			-- digits
 $alpha = [a-zA-Z]		-- alphabetic characters

--- a/tests/tokens_posn_bytestring.x
+++ b/tests/tokens_posn_bytestring.x
@@ -6,6 +6,7 @@ import Data.ByteString.Lazy.Char8 (unpack)
 }
 
 %wrapper "posn-bytestring"
+%encoding "UTF8"
 
 $digit = 0-9			-- digits
 $alpha = [a-zA-Z]		-- alphabetic characters

--- a/tests/tokens_strict_bytestring.x
+++ b/tests/tokens_strict_bytestring.x
@@ -6,6 +6,7 @@ import Data.ByteString.Char8 (unpack)
 }
 
 %wrapper "strict-bytestring"
+%encoding "ISO-8859-1"
 
 $digit = 0-9			-- digits
 $alpha = [a-zA-Z]		-- alphabetic characters


### PR DESCRIPTION
This addresses the motivating use-case behind #66 by implementing a new
directive which is inspired by the existing %wrapper directive. The
encoding string is matched case insensitive. Supported examples:

    %encoding "utf-8"
    %encoding "iso-8859-1"
    %encoding "UTF8"
    %encoding "Latin1"

Moreover, some logic has been added to abort if the combination of CLI
`--latin1` flags and %encoding directives contradict each other. For
instance, setting `--latin1` on the command-line while requesting
`%encoding "utf8"` in the Alex script causes Alex to abort with an error.