### PR TITLE
Fix compiler warnings in generated code

### DIFF
--- a/test.hs
+++ b/test.hs
@@ -1,4 +1,4 @@
-import System.Cmd (system)
+import System.Process (system)
 import System.Exit (exitWith)
 
 main = system "make -k -C tests clean all" >>= exitWith

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,6 @@
 ALEX=../dist/build/alex/alex
 HC=ghc
-HC_OPTS=-Wall -fno-warn-unused-binds -fno-warn-missing-signatures -fno-warn-unused-matches -fno-warn-name-shadowing -fno-warn-unused-imports -fno-warn-tabs -Werror
+HC_OPTS=-Wall -fno-warn-missing-signatures -fno-warn-name-shadowing -fno-warn-unused-imports -fno-warn-tabs -Werror
 
 .PRECIOUS: %.n.hs %.g.hs %.o %.exe %.bin
 
@@ -39,6 +39,6 @@ clean:
 	rm -f $(CLEAN_FILES)
 
 interact:
-	ghci -cpp -i../src -i../dist/build/autogen -i../dist/build/alex/alex-tmp Main -fbreak-on-exception 
+	ghci -cpp -i../src -i../dist/build/autogen -i../dist/build/alex/alex-tmp Main -fbreak-on-exception
 # -args='--template=.. simple.x -o simple.n.hs'
 # :set args --template=.. simple.x -o simple.n.hs

--- a/tests/null.x
+++ b/tests/null.x
@@ -34,25 +34,25 @@ $white+			;
 
 {
 {- we can now have comments in source code? -}
-word (p,_,_,input) len = return (take len input)
+word (_,_,_,input) len = return (take len input)
 
-null (p,_,_,input) len = return "\0"
+null (_,_,_,_) _ = return "\0"
 
-string (p,_,_,input) len = return (drop 1 (reverse (drop 1 (reverse input))))
+string (_,_,_,input) _ = return (drop 1 (reverse (drop 1 (reverse input))))
 
 alexEOF = return "stopped."
 
 scanner str = runAlex str $ do
   let loop = do tok <- alexMonadScan
-		if tok == "stopped." || tok == "error." 
+		if tok == "stopped." || tok == "error."
 			then return [tok]
 			else do toks <- loop
 				return (tok:toks)
-  loop  
+  loop
 
 main = do
   let test1 = scanner str1
-  when (test1 /= out1) $ 
+  when (test1 /= out1) $
 	do hPutStrLn stderr "Test 1 failed:"
 	   print test1
 	   exitFailure

--- a/tests/simple.x
+++ b/tests/simple.x
@@ -30,31 +30,31 @@ $white+			;
 
 {
 {- we can now have comments in source code? -}
-word (p,_,_,input) len = return (take len input)
+word (_,_,_,input) len = return (take len input)
 
-both (p,_,_,input) len = return ("BOTH:"++ take len input)
+both (_,_,_,input) len = return ("BOTH:"++ take len input)
 
-eol (p,_,_,input) len = return ("EOL:"++ take len input)
+eol (_,_,_,input) len = return ("EOL:"++ take len input)
 
-bol (p,_,_,input) len = return ("BOL:"++ take len input)
+bol (_,_,_,input) len = return ("BOL:"++ take len input)
 
-parenword (p,_,_,input) len = return (map toUpper (take len input))
+parenword (_,_,_,input) len = return (map toUpper (take len input))
 
-magic (p,_,_,input) len = return "PING!"
+magic (_,_,_,_) _ = return "PING!"
 
 alexEOF = return "stopped."
 
 scanner str = runAlex str $ do
   let loop = do tok <- alexMonadScan
-		if tok == "stopped." || tok == "error." 
+		if tok == "stopped." || tok == "error."
 			then return [tok]
 			else do toks <- loop
 				return (tok:toks)
-  loop  
+  loop
 
 main = do
   let test1 = scanner str1
-  when (test1 /= out1) $ 
+  when (test1 /= out1) $
 	do hPutStrLn stderr "Test 1 failed:"
 	   print test1
 	   exitFailure

--- a/tests/tokens.x
+++ b/tests/tokens.x
@@ -12,8 +12,8 @@ tokens :-
 
   $white+				;
   "--".*				;
-  let					{ \s -> Let }
-  in					{ \s -> In }
+  let					{ \_ -> Let }
+  in					{ \_ -> In }
   $digit+				{ \s -> Int (read s) }
   [\=\+\-\*\/\(\)]			{ \s -> Sym (head s) }
   $alpha [$alpha $digit \_ \']*		{ \s -> Var s }
@@ -31,7 +31,7 @@ data Token =
 	Sym Char	|
 	Var String	|
 	Int Int		|
-	Err 
+	Err
 	deriving (Eq,Show)
 
 main = if test1 /= result1 then exitFailure

--- a/tests/tokens_bytestring.x
+++ b/tests/tokens_bytestring.x
@@ -15,8 +15,8 @@ tokens :-
 
   $white+				;
   "--".*				;
-  let					{ \s -> Let }
-  in					{ \s -> In }
+  let					{ \_ -> Let }
+  in					{ \_ -> In }
   $digit+                               { \s -> Int (read (unpack s)) }
   [\=\+\-\*\/\(\)]                      { \s -> Sym (head (unpack s)) }
   $alpha [$alpha $digit \_ \']*         { \s -> Var (unpack s) }
@@ -31,7 +31,7 @@ data Token =
 	Sym Char	|
 	Var String	|
 	Int Int		|
-	Err 
+	Err
 	deriving (Eq,Show)
 
 main = if test1 /= result1 then exitFailure

--- a/tests/tokens_bytestring_unicode.x
+++ b/tests/tokens_bytestring_unicode.x
@@ -14,9 +14,9 @@ $alpha = [a-zA-Zαβ]    -- alphabetic characters
 tokens :-
 
   $white+        ;
-  "--".*        ;
-  let          { \s -> Let }
-  in          { \s -> In }
+  "--".*         ;
+  let            { \_ -> Let }
+  in             { \_ -> In }
   $digit+                               { \s -> Int (read (unpack s)) }
   [\=\+\-\*\/\(\)]                      { \s -> Sym (head (unpack s)) }
   $alpha [$alpha $digit \_ \']*         { \s -> Var (unpack s) }

--- a/tests/tokens_gscan.x
+++ b/tests/tokens_gscan.x
@@ -12,15 +12,15 @@ tokens :-
 
   $white+				;
   "--".*				;
-  let					{ tok (\p s -> Let p) }
-  in					{ tok (\p s -> In p) }
+  let					{ tok (\p _ -> Let p) }
+  in					{ tok (\p _ -> In p) }
   $digit+				{ tok (\p s -> Int p (read s)) }
   [\=\+\-\*\/\(\)]			{ tok (\p s -> Sym p (head s)) }
   $alpha [$alpha $digit \_ \']*		{ tok (\p s -> Var p s) }
 
 {
 -- Some action helpers:
-tok f p c str len cont (sc,state) = f p (take len str) : cont (sc,state)
+tok f p _ str len cont (sc,state) = f p (take len str) : cont (sc,state)
 
 -- The token type:
 data Token =
@@ -37,8 +37,8 @@ main = if test1 /= result1 then exitFailure
 
 test1 = alexGScan stop undefined "  let in 012334\n=+*foo bar__'"
 
-stop p c "" (sc,s) = []
-stop p c _  (sc,s) = error "lexical error"
+stop _ _ "" (_,_) = []
+stop _ _ _  (_,_) = error "lexical error"
 
 result1 = [Let (AlexPn 2 1 3),In (AlexPn 6 1 7),Int (AlexPn 9 1 10) 12334,Sym (AlexPn 16 2 1) '=',Sym (AlexPn 17 2 2) '+',Sym (AlexPn 18 2 3) '*',Var (AlexPn 19 2 4) "foo",Var (AlexPn 23 2 8) "bar__'"]
 }

--- a/tests/tokens_monadUserState_bytestring.x
+++ b/tests/tokens_monadUserState_bytestring.x
@@ -15,8 +15,8 @@ tokens :-
 
   $white+				;
   "--".*				;
-  let					{ tok (\p s -> Let p) }
-  in					{ tok (\p s -> In p) }
+  let					{ tok (\p _ -> Let p) }
+  in					{ tok (\p _ -> In p) }
   $digit+                               { tok (\p s -> Int p (read (B.unpack s))) }
   [\=\+\-\*\/\(\)]                      { tok (\p s -> Sym p (head (B.unpack s))) }
   $alpha [$alpha $digit \_ \']*         { tok (\p s -> Var p (B.unpack s)) }
@@ -52,7 +52,7 @@ scanner str = runAlex str $ do
 			then return [tok]
 			else do toks <- loop
 				return (tok:toks)
-  loop  
+  loop
 
 test1 = case scanner "  let in 012334\n=+*foo bar__'" of
           Left err -> error err

--- a/tests/tokens_monad_bytestring.x
+++ b/tests/tokens_monad_bytestring.x
@@ -15,8 +15,8 @@ tokens :-
 
   $white+				;
   "--".*				;
-  let					{ tok (\p s -> Let p) }
-  in					{ tok (\p s -> In p) }
+  let					{ tok (\p _ -> Let p) }
+  in					{ tok (\p _ -> In p) }
   $digit+                               { tok (\p s -> Int p (read (B.unpack s))) }
   [\=\+\-\*\/\(\)]                      { tok (\p s -> Sym p (head (B.unpack s))) }
   $alpha [$alpha $digit \_ \']*         { tok (\p s -> Var p (B.unpack s)) }
@@ -49,7 +49,7 @@ scanner str = runAlex str $ do
 			then return [tok]
 			else do toks <- loop
 				return (tok:toks)
-  loop  
+  loop
 
 test1 = case scanner "  let in 012334\n=+*foo bar__'" of
           Left err -> error err

--- a/tests/tokens_posn.x
+++ b/tests/tokens_posn.x
@@ -12,8 +12,8 @@ tokens :-
 
   $white+				;
   "--".*				;
-  let					{ tok (\p s -> Let p) }
-  in					{ tok (\p s -> In p) }
+  let					{ tok (\p _ -> Let p) }
+  in					{ tok (\p _ -> In p) }
   $digit+				{ tok (\p s -> Int p (read s)) }
   [\=\+\-\*\/\(\)]			{ tok (\p s -> Sym p (head s)) }
   $alpha [$alpha $digit \_ \']*		{ tok (\p s -> Var p s) }

--- a/tests/tokens_posn_bytestring.x
+++ b/tests/tokens_posn_bytestring.x
@@ -15,8 +15,8 @@ tokens :-
 
   $white+				;
   "--".*				;
-  let					{ tok (\p s -> Let p) }
-  in					{ tok (\p s -> In p) }
+  let					{ tok (\p _ -> Let p) }
+  in					{ tok (\p _ -> In p) }
   $digit+                               { tok (\p s -> Int p (read (unpack s))) }
   [\=\+\-\*\/\(\)]                      { tok (\p s -> Sym p (head (unpack s))) }
   $alpha [$alpha $digit \_ \']*         { tok (\p s -> Var p (unpack s)) }

--- a/tests/tokens_strict_bytestring.x
+++ b/tests/tokens_strict_bytestring.x
@@ -15,8 +15,8 @@ tokens :-
 
   $white+				;
   "--".*				;
-  let					{ \s -> Let }
-  in					{ \s -> In }
+  let					{ \_ -> Let }
+  in					{ \_ -> In }
   $digit+                               { \s -> Int (read (unpack s)) }
   [\=\+\-\*\/\(\)]                      { \s -> Sym (head (unpack s)) }
   $alpha [$alpha $digit \_ \']*         { \s -> Var (unpack s) }
@@ -31,7 +31,7 @@ data Token =
 	Sym Char	|
 	Var String	|
 	Int Int		|
-	Err 
+	Err
 	deriving (Eq,Show)
 
 main = if test1 /= result1 then exitFailure

--- a/tests/unicode.x
+++ b/tests/unicode.x
@@ -14,7 +14,7 @@ import System.IO
 
 tokens :-
 
-<0> {   
+<0> {
    "αω"        { string }
    [AΓ]        { character }
    .           { other }
@@ -23,13 +23,13 @@ tokens :-
 
 {
 string :: AlexInput -> Int -> Alex String
-string (p,_,_,input) len = return "string!"
+string (_,_,_,_) _ = return "string!"
 
 other :: AlexInput -> Int -> Alex String
-other (p,_,_,input) len = return (take len input)
+other (_,_,_,input) len = return (take len input)
 
 character :: AlexInput -> Int -> Alex String
-character (p,_,_,input) len = return "PING!"
+character (_,_,_,_) _ = return "PING!"
 
 alexEOF :: Alex String
 alexEOF = return "stopped."
@@ -37,16 +37,16 @@ alexEOF = return "stopped."
 scanner :: String -> Either String [String]
 scanner str = runAlex str $ do
   let loop = do tok <- alexMonadScan
-		if tok == "stopped." || tok == "error." 
+		if tok == "stopped." || tok == "error."
 			then return [tok]
 			else do toks <- loop
 				return (tok:toks)
-  loop  
+  loop
 
 main :: IO ()
 main = do
   let test1 = scanner str1
-  when (test1 /= out1) $ 
+  when (test1 /= out1) $
 	do hPutStrLn stderr "Test 1 failed:"
 	   print test1
 	   exitFailure


### PR DESCRIPTION
Warnings in the generated code makes it difficult to find warnings in user
code.

Tested with ghc 7.8.4, 7.10.3 and 8.0.1.