### PR TITLE
Convert README to markdown and update travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,22 @@
-language: haskell
+# language: haskell
+
+env:
+ - GHCVER=7.8.4
+ - GHCVER=7.10.3
+ - GHCVER=8.0.1
+
+before_install:
+ - sudo add-apt-repository -y ppa:hvr/ghc
+ - sudo apt-get update
+ - sudo apt-get install alex-3.1.7 happy-1.19.5 cabal-install-1.24 ghc-$GHCVER
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/alex/3.1.7/bin:/opt/happy/1.19.5/bin:$PATH
+
+install:
+ - cabal-1.24 update
+ - cabal-1.24 install --only-dependencies --enable-tests
+
+script:
+ - cabal-1.24 configure --enable-tests
+ - cabal-1.24 build
+ - dist/build/tests/tests
+ - cabal-1.24 sdist

--- a/README.md
+++ b/README.md
@@ -1,35 +1,40 @@
-		       Alex: A Lexical Analyser Generator
+# Alex: A Lexical Analyser Generator
+
+[![Build Status](https://secure.travis-ci.org/simonmar/alex.png?branch=master)](http://travis-ci.org/simonmar/alex)
 
 Alex is a Lex-like tool for generating Haskell scanners.  For complete
 documentation, see the doc directory.
 
    http://www.haskell.org/alex/
+
    http://hackage.haskell.org/package/alex
 
-Alex is built using Cabal.  First install GHC, then:
- 
-  $ runhaskell Setup.lhs configure
-  $ runhaskell Setup.lhs build
-  $ runhaskell Setup.lhs install
+Alex is built using Cabal.  First install GHC and cabal-install, then:
+
+    $ cabal configure
+    $ cabal build
+    $ cabal install
 
 Alex version 2.0 has changed fairly considerably since version 1.x,
 and the syntax is almost completely different.  For a detailed list of
 changes, see the release notes in the documentation.
 
 Alex is now covered by a BSD-Style licence; see the licence file in
-the `doc' directory for details.
+the 'doc' directory for details.
 
-The sources are in the the `src' directory and the documentation in the `doc'
+The sources are in the 'src' directory and the documentation in the 'doc'
 directory; various  examples are in the 'examples' subdirectory.
 
 The source code in the 'src' and 'examples' directories is intended
 for a Haskell 98 compiler with hierarchical modules.  It should work
 with GHC >= 5.04.
 
-Please report any bugs or comments to the email addresses given below.
+Please report any bugs or comments at  https://github.com/simonmar/alex/issues
 
 Share and enjoy,
 
 Chris Dornan:  cdornan@arm.com
+
 Isaac Jones:   ijones@syntaxpolice.org
+
 Simon Marlow:  simonmar@microsoft.com

--- a/alex.cabal
+++ b/alex.cabal
@@ -23,7 +23,7 @@ build-type: Custom
 
 extra-source-files:
         CHANGELOG.md
-        README
+        README.md
         TODO
         alex.spec
         doc/Makefile


### PR DESCRIPTION
This updated travis file builds and tests alex with the last three
major releases of GHC.

By converting the README to markdown we get a travis build status
badge on the README.