### PR TITLE
alex: fix generated type for 'alex_accept'

### DIFF
--- a/alex.cabal
+++ b/alex.cabal
@@ -61,6 +61,7 @@ extra-source-files:
         tests/tokens_posn.x
         tests/tokens_bytestring.x
         tests/tokens_posn_bytestring.x
+        tests/tokens_scan_user.x
         tests/tokens_strict_bytestring.x
         tests/tokens_monad_bytestring.x
         tests/tokens_monadUserState_bytestring.x

--- a/src/Output.hs
+++ b/src/Output.hs
@@ -71,14 +71,10 @@ outputDFA target _ _ scheme dfa
         . str "]\n"
 
     outputAccept =
-      let
-        userStateTy = case scheme of
-          Monad { monadUserState = True } -> "AlexUserState"
-          _ -> "()"
-      in
-          str accept_nm . str " :: Array Int (AlexAcc " . str userStateTy
-        . str ")\n" . str accept_nm
-        . str " = listArray (0::Int," . shows n_states . str ") ["
+        -- Don't emit explicit type signature as it contains unknown user type,
+        -- see: https://github.com/simonmar/alex/issues/98
+        -- str accept_nm . str " :: Array Int (AlexAcc " . str userStateTy . str ")\n"
+        str accept_nm . str " = listArray (0::Int," . shows n_states . str ") ["
         . interleave_shows (char ',') (snd (mapAccumR outputAccs 0 accept))
         . str "]\n"
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,7 +10,31 @@ else
 HS_PROG_EXT = .bin
 endif
 
-TESTS = unicode.x simple.x tokens.x tokens_posn.x tokens_gscan.x tokens_bytestring.x tokens_posn_bytestring.x tokens_strict_bytestring.x tokens_monad_bytestring.x tokens_monadUserState_bytestring.x null.x tokens_bytestring_unicode.x basic_typeclass.x basic_typeclass_bytestring.x strict_typeclass.x posn_typeclass.x posn_typeclass_bytestring.x gscan_typeclass.x monad_typeclass.x monad_typeclass_bytestring.x monadUserState_typeclass.x monadUserState_typeclass_bytestring.x default_typeclass.x
+TESTS = \
+        basic_typeclass.x \
+        basic_typeclass_bytestring.x \
+        default_typeclass.x \
+        gscan_typeclass.x \
+        monad_typeclass.x \
+        monad_typeclass_bytestring.x \
+        monadUserState_typeclass.x \
+        monadUserState_typeclass_bytestring.x \
+        null.x \
+        posn_typeclass.x \
+        posn_typeclass_bytestring.x \
+        strict_typeclass.x \
+        simple.x \
+        tokens.x \
+        tokens_bytestring.x \
+        tokens_bytestring_unicode.x \
+        tokens_gscan.x \
+        tokens_monad_bytestring.x \
+        tokens_monadUserState_bytestring.x \
+        tokens_posn.x \
+        tokens_posn_bytestring.x \
+        tokens_scan_user.x \
+        tokens_strict_bytestring.x \
+        unicode.x
 
 TEST_ALEX_OPTS = --template=..
 

--- a/tests/tokens_scan_user.x
+++ b/tests/tokens_scan_user.x
@@ -1,0 +1,50 @@
+{
+module Main (main) where
+import System.Exit
+}
+
+%wrapper "basic" -- Defines: AlexInput, alexGetByte, alexPrevChar
+
+$digit = 0-9
+$alpha = [a-zA-Z]
+$ws    = [\ \t\n]
+
+tokens :-
+
+  5 / {\u _ibt _l _iat -> u == FiveIsMagic} { \s -> TFive (head s) }
+  $digit { \s -> TDigit (head s) }
+  $alpha { \s -> TAlpha (head s) }
+  $ws    { \s -> TWSpace (head s) }
+
+{
+
+data Token = TDigit Char
+           | TAlpha Char
+           | TWSpace Char
+           | TFive Char -- Predicated only
+           | TLexError
+    deriving (Eq,Show)
+
+data UserLexerMode = NormalMode
+                   | FiveIsMagic
+    deriving Eq
+
+main | test1 /= result1 = exitFailure
+     | test2 /= result2 = exitFailure
+     -- all succeeded
+     | otherwise        = exitWith ExitSuccess
+
+run_lexer :: UserLexerMode -> String -> [Token]
+run_lexer m s = go ('\n', [], s)
+    where go i@(_,_,s') = case alexScanUser m i 0 of
+                     AlexEOF             -> []
+                     AlexError  _i       -> [TLexError]
+                     AlexSkip   i' _len  ->                   go i'
+                     AlexToken  i' len t -> t (take len s') : go i'
+
+test1 = run_lexer FiveIsMagic "5 x"
+result1 = [TFive '5',TWSpace ' ',TAlpha 'x']
+
+test2 = run_lexer NormalMode "5 x"
+result2 = [TDigit '5',TWSpace ' ',TAlpha 'x']
+}


### PR DESCRIPTION
The change fixes lexer generation failure for GHC lexer.
GHC lexer is special because it calls `alexScanUser`
to thread lexer state.

Added minimal test `tokens_scan_user.x`
to cover `alexScanUser` use.

Signature was reintroduced in commit 00431304aa18ada0a12aab43443023a86521f353
accidentally.

Fixes https://github.com/simonmar/alex/issues/98

Signed-off-by: Sergei Trofimovich <siarheit@google.com>