### PR TITLE
fix tiny bug in pattern match

### DIFF
--- a/doc/alex.xml
+++ b/doc/alex.xml
@@ -1299,7 +1299,7 @@ alexGetByte (_,[],(c:s)) = case utf8Encode c of
                              (b:bs) -> Just (b, (c, bs, s))
 
 alexInputPrevChar :: AlexInput -> Char
-alexInputPrevChar (c,_) = c
+alexInputPrevChar (c,_,_) = c
 
 -- alexScanTokens :: String -> [token]
 alexScanTokens str = go ('\n',[],str)


### PR DESCRIPTION
I fixed a small bug in the pattern match of function `alexInputPrevChar` in the wrappers chapter.