### PR TITLE
Add docbook xml path as currently found in Arch Linux

### DIFF
--- a/doc/configure.ac
+++ b/doc/configure.ac
@@ -5,7 +5,7 @@ AC_CONFIG_SRCDIR([Makefile])
 
 dnl ** check for DocBook toolchain
 FP_CHECK_DOCBOOK_DTD
-FP_DIR_DOCBOOK_XSL([/usr/share/xml/docbook/stylesheet/nwalsh/current /usr/share/xml/docbook/stylesheet/nwalsh /usr/share/sgml/docbook/docbook-xsl-stylesheets* /usr/share/sgml/docbook/xsl-stylesheets* /opt/kde?/share/apps/ksgmltools2/docbook/xsl /usr/share/docbook-xsl /usr/share/sgml/docbkxsl /usr/local/share/xsl/docbook /sw/share/xml/xsl/docbook-xsl])
+FP_DIR_DOCBOOK_XSL([/usr/share/xml/docbook/stylesheet/nwalsh/current /usr/share/xml/docbook/stylesheet/nwalsh /usr/share/sgml/docbook/docbook-xsl-stylesheets* /usr/share/sgml/docbook/xsl-stylesheets* /opt/kde?/share/apps/ksgmltools2/docbook/xsl /usr/share/docbook-xsl /usr/share/sgml/docbkxsl /usr/local/share/xsl/docbook /sw/share/xml/xsl/docbook-xsl /usr/share/xml/docbook/xsl-stylesheets*])
 
 AC_PATH_PROG(DbLatexCmd,dblatex)
 


### PR DESCRIPTION
Allow Arch's makepkg to build and install documentation as expected.  Currently, on Arch, alex's document doesn't seem to be provided when alex is installed using the pacman package manager. (https://github.com/simonmar/alex/issues/113)