### PR TITLE
add stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,4 @@
+resolver: lts-9.6
+packages:
+- .
+


### PR DESCRIPTION
generated by `stack init`, then removed noisy comments. `stack build` works as expected on Archlinux and FreeBSD.