### PR TITLE
Fix warnings about non-exhaustive patterns

### DIFF
--- a/templates/wrappers.hs
+++ b/templates/wrappers.hs
@@ -33,7 +33,8 @@ utf8Encode :: Char -> [Word8]
 utf8Encode = uncurry (:) . utf8Encode'
 
 utf8Encode' :: Char -> (Word8, [Word8])
-utf8Encode' c = (fromIntegral x, map fromIntegral xs)
+utf8Encode' c = case go (ord c) of
+                  (x, xs) -> (fromIntegral x, map fromIntegral xs)
  where
   go oc
    | oc <= 0x7f       = ( oc
@@ -53,7 +54,6 @@ utf8Encode' c = (fromIntegral x, map fromIntegral xs)
                         , 0x80 + ((oc `Data.Bits.shiftR` 6) Data.Bits..&. 0x3f)
                         , 0x80 + oc Data.Bits..&. 0x3f
                         ])
-  (x, xs) = go (ord c)
 
 #endif
 
@@ -78,8 +78,8 @@ alexGetByte :: AlexInput -> Maybe (Byte,AlexInput)
 alexGetByte (p,c,(b:bs),s) = Just (b,(p,c,bs,s))
 alexGetByte (_,_,[],[]) = Nothing
 alexGetByte (p,_,[],(c:s))  = let p' = alexMove p c
-                                  (b, bs) = utf8Encode' c
-                              in p' `seq`  Just (b, (p', c, bs, s))
+                              in case utf8Encode' c of
+                                   (b, bs) -> p' `seq`  Just (b, (p', c, bs, s))
 #endif
 
 #if defined(ALEX_POSN_BYTESTRING) || defined(ALEX_MONAD_BYTESTRING)
@@ -340,8 +340,8 @@ alexScanTokens str = go ('\n',[],str)
 alexGetByte :: AlexInput -> Maybe (Byte,AlexInput)
 alexGetByte (c,(b:bs),s) = Just (b,(c,bs,s))
 alexGetByte (_,[],[])    = Nothing
-alexGetByte (_,[],(c:s)) = let (b, bs) = utf8Encode' c
-                           in Just (b, (c, bs, s))
+alexGetByte (_,[],(c:s)) = case utf8Encode' c of
+                             (b, bs) -> Just (b, (c, bs, s))
 #endif
 
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,7 +13,7 @@ endif
 
 # NOTE: This assumes that a working `ghc` is on $PATH; this may not necessarily be the same GHC used by `cabal` for building `alex`.
 HC=ghc
-HC_OPTS=-Wall -fno-warn-missing-signatures -fno-warn-unused-imports -fno-warn-tabs -Werror
+HC_OPTS=-Wall -fwarn-incomplete-uni-patterns -fno-warn-missing-signatures -fno-warn-unused-imports -fno-warn-tabs -Werror
 
 .PRECIOUS: %.n.hs %.g.hs %.o %.exe %.bin
 

--- a/tests/default_typeclass.x
+++ b/tests/default_typeclass.x
@@ -52,7 +52,8 @@ tokens :-
 
 -- | Encode a Haskell String to a list of Word8 values, in UTF8 format.
 utf8Encode' :: Char -> (Word8, [Word8])
-utf8Encode' c = (fromIntegral x, map fromIntegral xs)
+utf8Encode' c = case go (ord c) of
+                  (x, xs) -> (fromIntegral x, map fromIntegral xs)
  where
   go oc
    | oc <= 0x7f       = ( oc
@@ -72,7 +73,6 @@ utf8Encode' c = (fromIntegral x, map fromIntegral xs)
                         , 0x80 + ((oc `Data.Bits.shiftR` 6) Data.Bits..&. 0x3f)
                         , 0x80 + oc Data.Bits..&. 0x3f
                         ])
-  (x, xs) = go (ord c)
 
 type Byte = Word8
 
@@ -102,8 +102,8 @@ alexGetByte :: AlexInput -> Maybe (Byte,AlexInput)
 alexGetByte (p,c,(b:bs),s) = Just (b,(p,c,bs,s))
 alexGetByte (_,_,[],[]) = Nothing
 alexGetByte (p,_,[],(c:s))  = let p' = alexMove p c
-                                  (b, bs) = utf8Encode' c
-                              in p' `seq`  Just (b, (p', c, bs, s))
+                              in case utf8Encode' c of
+                                   (b, bs) -> p' `seq`  Just (b, (p', c, bs, s))
 
 data AlexPosn = AlexPn !Int !Int !Int
         deriving (Eq,Show)


### PR DESCRIPTION
The utf8encode function always returned a list of at least one element,
but the type system didn't prove this, leading to spurious warnings when
taking the first element of the returned list. Fix this by returning a
tuple with the first element separate instead. (I would have used
Data.List.NonEmpty but it looks like we still support ancient GHC versions
that didn't yet have it.)