### PR TITLE
Avoid trigraph warning

### DIFF
--- a/src/CharSet.hs
+++ b/src/CharSet.hs
@@ -121,7 +121,7 @@ byteRangeToBytePair :: Span [Byte] -> ([Byte],[Byte])
 byteRangeToBytePair (Span x y) = (x,y)
 
 data Span a = Span a a -- lower bound inclusive, higher bound exclusive
-                       -- (SDM: upper bound inclusive, surely??)
+                       -- (SDM: upper bound inclusive, surely?)
 instance Functor Span where
     fmap f (Span x y) = Span (f x) (f y)
 


### PR DESCRIPTION
For reasons not entirely clear, when compiling Alex with Bazel I get a warning about an invalid trigraph (it's probably doing its own CPP stuff or using its own options). It's not a fatal warning, but seems easy enough to avoid in this instance.