### PR TITLE
Revert "Add a proper implementation of fail to the Alex monad"

### DIFF
--- a/templates/wrappers.hs
+++ b/templates/wrappers.hs
@@ -6,9 +6,6 @@
 
 #if defined(ALEX_MONAD) || defined(ALEX_MONAD_BYTESTRING)
 import Control.Applicative as App (Applicative (..))
-#if __GLASGOW_HASKELL__ >= 800
-import qualified Control.Monad.Fail as Fail
-#endif
 #endif
 
 import Data.Word (Word8)
@@ -228,14 +225,6 @@ instance Monad Alex where
                                 Left msg -> Left msg
                                 Right (s',a) -> unAlex (k a) s'
   return = App.pure
-#if __GLASGOW_HASKELL__ < 800
-  fail = alexError
-#else
-  fail = Fail.fail
-
-instance Fail.MonadFail Alex where
-  fail = alexError
-#endif
 
 alexGetInput :: Alex AlexInput
 alexGetInput


### PR DESCRIPTION
The GHC version detection didn't actually work right, resulting in the `__GLASGOW_HASKELL__ < 800` branch always being taken. This became apparent once I tried using GHC 8.8, as the fallback of `fail` inside `Monad` is no longer there, so it fails to compile. We need to fix this by playing the same sort of double-#define games that GenericTemplate.hs does. I plan to do that in a later PR but would like to unbreak this for now. Since there's been no release of Alex since this was added, this shouldn't qualify as a breaking change.

Reverts simonmar/alex#136