### PR TITLE
Remove fail from default_typeclass test

### DIFF
--- a/tests/default_typeclass.x
+++ b/tests/default_typeclass.x
@@ -285,7 +285,6 @@ instance (Monad m) => Monad (StateT s m) where
     m >>= k  = StateT $ \s -> do
         (a, s') <- runStateT m s
         runStateT (k a) s'
-    fail str = StateT $ \_ -> fail str
 
 -- | Fetch the current value of the state within the monad.
 get' :: (Monad m) => StateT s m s


### PR DESCRIPTION
This was added when we copied in StateT from MTL, but we don't actually
use it. Since the MonadFail Proposal was finished in GHC 8.8.1, it now
breaks compiling, so remove it.