### PR TITLE
Fix build with GHC HEAD (8.11)

### DIFF
--- a/src/DFAMin.hs
+++ b/src/DFAMin.hs
@@ -32,9 +32,9 @@ import Data.List as List
 -- end;
 
 minimizeDFA :: Ord a => DFA Int a -> DFA Int a
-minimizeDFA  dfa@ DFA { dfa_start_states = starts,
-                        dfa_states       = statemap
-                      }
+minimizeDFA  dfa@DFA { dfa_start_states = starts,
+                       dfa_states       = statemap
+                     }
   = DFA { dfa_start_states = starts,
           dfa_states       = Map.fromList states }
   where


### PR DESCRIPTION
With GHC HEAD (8.11), build fails with

```
> /tmp/stack86151/alex-3.2.5/src/DFAMin.hs:35:17: error:
>     Suffix occurrence of @. For an as-pattern, remove the leading whitespace.
>    |       
> 35 | minimizeDFA  dfa@ DFA { dfa_start_states = starts,
>    |                 ^
```

This fixes that issue.
