### PR TITLE
CI: test also ghc 8.6 and 8.8 on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 .cabal-sandbox
 .stack-work
 cabal.sandbox.config
+/src/TAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 # language: haskell
 
+# Keep the list of tested GHC versions in sync with `tested-with` in `alex.cabal`.
 env:
+ - GHCVER=8.8.2
+ - GHCVER=8.6.5
 # - GHCVER=7.0.4
  - GHCVER=7.4.2
  - GHCVER=7.6.3
@@ -8,7 +11,7 @@ env:
  - GHCVER=7.10.3
  - GHCVER=8.0.2
  - GHCVER=8.2.2
- - GHCVER=8.4.1
+ - GHCVER=8.4.4
 
 before_install:
  - sudo add-apt-repository -y ppa:hvr/ghc

--- a/alex.cabal
+++ b/alex.cabal
@@ -21,6 +21,18 @@ description:
 category: Development
 build-type: Simple
 
+-- Keep the contents of `tested-with` in sync with `env` in `.travis.yml`.
+tested-with:
+        GHC == 7.4.2
+        GHC == 7.6.3
+        GHC == 7.8.4
+        GHC == 7.10.3
+        GHC == 8.0.2
+        GHC == 8.2.2
+        GHC == 8.4.4
+        GHC == 8.6.5
+        GHC == 8.8.2
+
 data-dir: data/
 
 data-files:


### PR DESCRIPTION
This simple PR extends `.travis.yml` to also test compilation of `alex` under ghc 8.6/8. 