### PR TITLE
[ fixed #46 ] give proper error when no lexing rules

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -113,7 +113,11 @@ parseScript file prg =
         Left (Nothing, err) ->
                 die (file ++ ": " ++ err ++ "\n")
 
-        Right script -> return script
+        Right script@(_, _, scanner, _) -> do
+          -- issue 46: give proper error when lexer definition is empty
+          when (null $ scannerTokens scanner) $
+            dieAlex $ file ++ " contains no lexer rules\n"
+          return script
 
 alex :: [CLIFlags]
      -> FilePath


### PR DESCRIPTION
The new error
```
  file.x contains no lexer rules
```
can be tested with `file.x` containing
```
  :- <0> { }
```
The previous error was
```
  (Array.!): undefined array element
```
(I did not find a testsuite testing for error messages Alex gives, thus,
no test case with this commit.)