### PR TITLE
[ fixed #141 ] regex: allow arbitary repetitions

### DIFF
--- a/alex.cabal
+++ b/alex.cabal
@@ -122,6 +122,7 @@ extra-source-files:
         tests/unicode.x
         tests/issue_71.x
         tests/issue_119.x
+        tests/issue_141.x
 
 source-repository head
     type:     git

--- a/doc/alex.xml
+++ b/doc/alex.xml
@@ -822,9 +822,9 @@ rexp0   := set
          | @string
          | '(' [ regexp ] ')'
 
-repeat  := '{' $digit '}'
-         | '{' $digit ',' '}'
-         | '{' $digit ',' $digit '}'</programlisting>
+repeat  := '{' $digit+ '}'
+         | '{' $digit+ ',' '}'
+         | '{' $digit+ ',' $digit+ '}'</programlisting>
 
       <para>The syntax of regular expressions is fairly standard, the
       only difference from normal lex-style regular expressions being

--- a/src/Parser.y
+++ b/src/Parser.y
@@ -54,6 +54,7 @@ import Data.Char
 	ID		{ T _ (IdT $$) }
 	CODE		{ T _ (CodeT _) }
 	CHAR		{ T _ (CharT $$) }
+	NUM		{ T _ (NumT $$) }
 	SMAC		{ T _ (SMacT _) }
 	RMAC		{ T _ (RMacT $$) }
 	SMAC_DEF	{ T _ (SMacDefT $$) }
@@ -166,11 +167,15 @@ rep	:: { RExp -> RExp }
 	: '*' 				{ Star }
 	| '+' 				{ Plus }
 	| '?' 				{ Ques }
+					-- Single digits are CHAR, not NUM.
 					-- TODO: these don't check for digits
 					-- properly.
 	| '{' CHAR '}'			{ repeat_rng (digit $2) Nothing }
 	| '{' CHAR ',' '}'		{ repeat_rng (digit $2) (Just Nothing) }
 	| '{' CHAR ',' CHAR '}' 	{ repeat_rng (digit $2) (Just (Just (digit $4))) }
+	| '{' NUM '}'			{ repeat_rng $2 Nothing }
+	| '{' NUM ',' '}'		{ repeat_rng $2 (Just Nothing) }
+	| '{' NUM ',' NUM '}'           { repeat_rng $2 (Just (Just $4)) }
 
 rexp0	:: { RExp }
 	: '(' ')'  			{ Eps }

--- a/src/Scan.x
+++ b/src/Scan.x
@@ -56,7 +56,8 @@ alex :-
 <0> \\ x $hexdig+               { hexch }
 <0> \\ o $octal+                { octch }
 <0> \\ $printable               { escape }
-<0> $nonspecial # [\<]          { char }
+<0> $nonspecial # [\<]          { char } -- includes 1 digit numbers
+<0> $digit+                     { num  } -- should be after char
 <0> @smac                       { smac }
 <0> @rmac                       { rmac }
 
@@ -120,6 +121,7 @@ decch     (p,_,str) ln = return $ T p (CharT (do_ech 10 ln (take (ln-1) (tail st
 hexch     (p,_,str) ln = return $ T p (CharT (do_ech 16 ln (take (ln-2) (drop 2 str))))
 octch     (p,_,str) ln = return $ T p (CharT (do_ech 8  ln (take (ln-2) (drop 2 str))))
 char      (p,_,str) _  = return $ T p (CharT (head str))
+num       (p,_,str) ln = return $ T p $ NumT $ parseInt 10 $ take ln str
 smac      (p,_,str) ln = return $ T p (SMacT (mac ln str))
 rmac      (p,_,str) ln = return $ T p (RMacT (mac ln str))
 smacdef   (p,_,str) ln = return $ T p (SMacDefT (macdef ln str))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -42,6 +42,7 @@ TESTS = \
         gscan_typeclass.x \
         issue_71.x \
         issue_119.x \
+        issue_141.x \
         monad_typeclass.x \
         monad_typeclass_bytestring.x \
         monadUserState_typeclass.x \

--- a/tests/issue_141.x
+++ b/tests/issue_141.x
@@ -1,0 +1,40 @@
+{
+-- Issue #141
+-- reported 2015-10-20 by Iavor S. Diatchki
+-- fixed 2020-01-31 by Andreas Abel
+--
+-- Problem was:
+-- Only one-digit numbers were accepted in repetition ranges.
+
+module Main (main) where
+
+import System.Exit
+}
+
+%wrapper "posn"
+%token   "Token"
+
+:-
+
+-- allow several digits in repetition ranges, e.g. 14
+"a"{14,14}          { \ _ _ -> A }
+[\ \n\t]+           ;
+
+{
+data Token = A
+  deriving (Eq, Show)
+
+                -- 12345678901234
+input           = "aaaaaaaaaaaaaa\n"  -- fourteen a's
+expected_result = [A]
+
+main :: IO ()
+main
+  | result == expected_result = do
+      exitWith ExitSuccess
+  | otherwise = do
+      print $ take 20 result
+      exitFailure
+  where
+  result = alexScanTokens input
+}


### PR DESCRIPTION
Previously, the `r{n,m}` and related forms were restricted to single
digit numbers `n` and `m`.

We fix this by recognizing numbers of > 1 digits as NUM token and adding
rules to the regex parsing that also allows NUMs for `n` and `m`.
Previously, only CHAR was allowed, which subsumes single digits.