### PR TITLE
[ travis ] test ghc 8.10 compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,8 @@ env:
  - GHCVER=8.2.2
  - GHCVER=8.4.4
  - GHCVER=8.6.5
- - GHCVER=8.8.2
+ - GHCVER=8.8.3
+ - GHCVER=8.10.1
 
 before_install:
  - sudo add-apt-repository -y ppa:hvr/ghc

--- a/alex.cabal
+++ b/alex.cabal
@@ -32,7 +32,8 @@ tested-with:
         GHC == 8.2.2
         GHC == 8.4.4
         GHC == 8.6.5
-        GHC == 8.8.2
+        GHC == 8.8.3
+        GHC == 8.10.1
 
 data-dir: data/
 


### PR DESCRIPTION
Added ghc 8.10.1 to the travis matrix.
Also included GHC == 8.10.1 in the 'tested-with:' field.