### PR TITLE
Fix left context with UTF-8 input in bytestring wrappers

### DIFF
--- a/templates/wrappers.hs
+++ b/templates/wrappers.hs
@@ -103,8 +103,9 @@ alexGetByte (p,c,cc,bl,cs,n) =
     case ByteString.uncons cs of
         Nothing -> Nothing
         Just (b, cs') ->
-            let (p',c',cc',bl') = flush . shift $ fromIntegral b
-                n'              = n+1
+            let (cc',bl') = shift (fromIntegral b)
+                (p',c')   = flush cc' bl'
+                n'        = n+1
             in p' `seq` cc' `seq` cs' `seq` n' `seq` Just (b, (p', c', cc', bl', cs',n'))
  where
   shift b
@@ -114,10 +115,10 @@ alexGetByte (p,c,cc,bl,cs,n) =
    | b <= 0xef = (b Data.Bits..&. 0x0f,2)
    | otherwise = (b Data.Bits..&. 0x07,3)
 
-  flush (cc',0)   = let c' = Data.Char.chr cc'
+  flush cc'  0    = let c' = Data.Char.chr cc'
                         p' = alexMove p c'
-                    in (p',c',0,0)
-  flush (cc',bl') = (p,c,cc',bl')
+                    in (p',c')
+  flush _cc' _bl' = (p,c)
 #endif
 
 #ifdef ALEX_BASIC_BYTESTRING
@@ -134,7 +135,8 @@ alexGetByte (AlexInput {alexChar=pc,alexCurChar=cc,alexBytesLeft=bl,alexStr=cs,a
     case ByteString.uncons cs of
         Nothing -> Nothing
         Just (c, rest) ->
-            let (pc',cc',bl') = flush . shift $ fromIntegral c
+            let (cc',bl') = shift (fromIntegral c)
+                pc'       = flush cc' bl'
             in Just (c, AlexInput {
                 alexChar = pc',
                 alexCurChar = cc',
@@ -149,9 +151,8 @@ alexGetByte (AlexInput {alexChar=pc,alexCurChar=cc,alexBytesLeft=bl,alexStr=cs,a
    | b <= 0xef = (b Data.Bits..&. 0x0f,2)
    | otherwise = (b Data.Bits..&. 0x07,3)
 
-  flush (cc',0)   = let c' = Data.Char.chr cc'
-                    in (c',0,0)
-  flush (cc',bl') = (pc,cc',bl')
+  flush cc'  0    = Data.Char.chr cc'
+  flush _cc' _bl' = pc
 #endif
 
 #ifdef ALEX_STRICT_BYTESTRING
@@ -168,7 +169,8 @@ alexGetByte (AlexInput {alexChar=pc,alexCurChar=cc,alexBytesLeft=bl,alexStr=cs,a
     case ByteString.uncons cs of
         Nothing -> Nothing
         Just (c, rest) ->
-            let (pc',cc',bl') = flush . shift $ fromIntegral c
+            let (cc',bl') = shift (fromIntegral c)
+                pc'       = flush cc' bl'
             in Just (c, AlexInput {
                 alexChar = pc',
                 alexCurChar = cc',
@@ -183,9 +185,8 @@ alexGetByte (AlexInput {alexChar=pc,alexCurChar=cc,alexBytesLeft=bl,alexStr=cs,a
    | b <= 0xef = (b Data.Bits..&. 0x0f,2)
    | otherwise = (b Data.Bits..&. 0x07,3)
 
-  flush (cc',0)   = let c' = Data.Char.chr cc'
-                    in (c',0,0)
-  flush (cc',bl') = (pc,cc',bl')
+  flush cc'  0    = Data.Char.chr cc'
+  flush _cc' _bl' = pc
 #endif
 
 -- -----------------------------------------------------------------------------

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -40,6 +40,7 @@ TESTS = \
         basic_typeclass_bytestring.x \
         default_typeclass.x \
         gscan_typeclass.x \
+        issue_53.x \
         issue_71.x \
         issue_119.x \
         issue_141.x \

--- a/tests/issue_53.x
+++ b/tests/issue_53.x
@@ -1,0 +1,22 @@
+{
+{-# LANGUAGE OverloadedStrings #-}
+module Main (main) where
+import System.Exit
+import qualified Data.Text.Lazy as T
+import Data.Text.Lazy.Encoding
+}
+
+%wrapper "basic-bytestring"
+
+tokens :-
+
+  ∃^∀    { const True }
+  ∃      { const True }
+  .      { const False }
+
+{
+main :: IO ()
+main = if and . alexScanTokens . encodeUtf8 $ "∃∀"
+           then exitWith ExitSuccess
+           else exitFailure
+}

--- a/tests/monadUserState_typeclass_bytestring.x
+++ b/tests/monadUserState_typeclass_bytestring.x
@@ -59,7 +59,7 @@ tokpred :: AlexUserState -> AlexInput -> Int -> AlexInput -> Bool
 tokpred _ _ _ _ = True
 
 idtoken :: Read s => Int -> AlexInput -> Int64 -> Alex (Token s)
-idtoken n (_, _, s, _) len =
+idtoken n (_, _, _, _, s, _) len =
   return (Id n (read ("\"" ++ Lazy.unpack (Lazy.take (fromIntegral len) s) ++
                       "\"")))
 

--- a/tests/monad_typeclass_bytestring.x
+++ b/tests/monad_typeclass_bytestring.x
@@ -55,7 +55,7 @@ tokpred :: () -> AlexInput -> Int -> AlexInput -> Bool
 tokpred _ _ _ _ = True
 
 idtoken :: Read s => Int -> AlexInput -> Int64 -> Alex (Token s)
-idtoken n (_, _, s, _) len =
+idtoken n (_, _, _, _, s, _) len =
   return (Id n (read ("\"" ++ Lazy.unpack (Lazy.take (fromIntegral len) s) ++
                       "\"")))
 

--- a/tests/tokens_monadUserState_bytestring.x
+++ b/tests/tokens_monadUserState_bytestring.x
@@ -25,7 +25,7 @@ tokens :-
 -- Each right-hand side has type :: AlexPosn -> String -> Token
 
 -- Some action helpers:
-tok f (p,_,input,_) len = return (f p (B.take (fromIntegral len) input))
+tok f (p,_,_,_,input,_) len = return (f p (B.take (fromIntegral len) input))
 
 -- The token type:
 data Token =

--- a/tests/tokens_monad_bytestring.x
+++ b/tests/tokens_monad_bytestring.x
@@ -25,7 +25,7 @@ tokens :-
 -- Each right-hand side has type :: AlexPosn -> String -> Token
 
 -- Some action helpers:
-tok f (p,_,input,_) len = return (f p (B.take (fromIntegral len) input))
+tok f (p,_,_,_,input,_) len = return (f p (B.take (fromIntegral len) input))
 
 -- The token type:
 data Token =


### PR DESCRIPTION
Fixes #53

In the original implementation of the bytestring wrappers, `alexGetByte` maintains the last seen *byte* instead of the last seen *character*. This causes the left context to cease proper function. This patch introduces a fix of the issue.

Since I have to change the structure of the `AlexInput` type, this is a breaking change.