### PR TITLE
tests/default_typeclass.x: remove spaces around as-pattern

### DIFF
--- a/tests/default_typeclass.x
+++ b/tests/default_typeclass.x
@@ -133,7 +133,7 @@ alexSetInput (pos, c, bs, inp) =
 alexError :: (MonadState AlexState m, Read s) => String -> m (Token s)
 alexError message =
   do
-    s @ AlexState { alex_errs = errs } <- get
+    s@AlexState { alex_errs = errs } <- get
     put s { alex_errs = message : errs }
     alexMonadScan
 


### PR DESCRIPTION
I'm getting the following error when trying to run the tests with GHC 9.0.1:

```
ghc -Wall -fwarn-incomplete-uni-patterns -fno-warn-missing-signatures -fno-warn-unused-imports -fno-warn-tabs -Werror -package array -package bytestring  default_typeclass.n.hs -o default_typeclass.n.bin
[1 of 1] Compiling Main             ( default_typeclass.n.hs, default_typeclass.n.o )

default_typeclass.x:136:7: error:
    Found a binding for the ‘@’ operator in a pattern position.
    Perhaps you meant an as-pattern, which must not be surrounded by whitespace
    Possibly caused by a missing 'do'?
    |
136 |     s @ AlexState { alex_errs = errs } <- get
    |       ^
make: *** [Makefile:72: default_typeclass.n.bin] Error 1
/build/alex-3.2.6/dist/build/alex/alex  -g default_typeclass.x -o default_typeclass.g.hs
ghc -Wall -fwarn-incomplete-uni-patterns -fno-warn-missing-signatures -fno-warn-unused-imports -fno-warn-tabs -Werror -package array -package bytestring  default_typeclass.g.hs -o default_typeclass.g.bin
[1 of 1] Compiling Main             ( default_typeclass.g.hs, default_typeclass.g.o )

default_typeclass.x:136:7: error:
    Found a binding for the ‘@’ operator in a pattern position.
    Perhaps you meant an as-pattern, which must not be surrounded by whitespace
    Possibly caused by a missing 'do'?
    |
136 |     s @ AlexState { alex_errs = errs } <- get
    |       ^

```